### PR TITLE
Complete 70-no-dejavu with other interfering fonts

### DIFF
--- a/70-no-dejavu.conf
+++ b/70-no-dejavu.conf
@@ -24,6 +24,34 @@
                     <string>DejaVu Sans Mono</string>
                 </patelt>
             </pattern>
+            <!-- Times New Roman also, e.g. on U+2764 / HEAVY BLACK HEART -->
+            <pattern>
+                <patelt name="family">
+                    <string>Times New Roman</string>
+                </patelt>
+            </pattern>
+            <!-- Some Google Web Fonts also contain interfering characters -->
+            <pattern>
+                <patelt name="family">
+                    <string>Arimo</string>
+                </patelt>
+            </pattern>
+            <pattern>
+                <patelt name="family">
+                    <string>Nimbus Sans</string>
+                </patelt>
+            </pattern>
+            <pattern>
+                <patelt name="family">
+                    <string>Noto Sans</string>
+                </patelt>
+            </pattern>
+            <!-- And Tinos, from ChromeOS core fonts -->
+            <pattern>
+                <patelt name="family">
+                    <string>Tinos</string>
+                </patelt>
+            </pattern>
         </rejectfont>
     </selectfont>
 


### PR DESCRIPTION
This is a followup of [reddit / Archlinux / How to priorize Noto Emoji over monochrome emoji provided by other system fonts](https://www.reddit.com/r/archlinux/comments/9ouk2o/how_to_priorize_emojione_noto_emoji_over/).

---

**EDIT**: I see [README / Emoji in common families](https://github.com/stove-panini/fontconfig-emoji#emoji-in-common-families) (and README's sour PS 🙂) mentions the issue. I guess my patch it a little bit intense, then. What about an additional `70-no-conflictual-common-families.conf` file instead, that I'd reference in that paragraph? I should add `Liberation` here, too.

And if I may, you say you like, for functional emoji,

> 1.   Bitstream Vera
> 2.   Liberation and/or URW for metric aliases
> 3.   Google Noto Color Emoji
> 4.   Symbola to slurp up the rest of those non-emoji symbols

→ 1,3,4 sound right, but doesn't Liberation stealing (with a sad naked monochrome glyph) chars like "❤" bother you, of am I missing something?

---

Also, the weirdest thing: when the (existing) `rejectfont / DejaVu Sans` rule is on, Nautilus starts using a weird triple colon `⫶` glyph instead of a regular `:` colon in HH:MM file dates, increasing line height. WTF. Same for you? (if you use Nautilus)

![screenshot_no-dejavu-triplecolon-nautilus_2018-10-20-17 10 33](https://user-images.githubusercontent.com/522085/47260533-6bdd2d80-d48b-11e8-890d-e5a32dd8fa47.png)
